### PR TITLE
Add right-click menu and wheel zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 - Prompt for username on connect
 - Host or join a session
 - Host can enable/disable drawing for each user
-- Dark mode (default) and light mode toggle
+- Dark mode (default) and light mode toggle via right-click menu
 - Whiteboard centered and uses 80% of the window
-- Zoom in up to 180%, never smaller than 100%
+- Zoom with mouse wheel up to 180%, never smaller than 100%
 
 ## Quick Start
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 version: '3'
 services:
-  app:
+  whiteboard:
     build: .
     ports:
       - "3000:3000"
     volumes:
-      - .:/app
-    environment:
-      - PORT=3000
+      - ./public:/app/public
+    restart: unless-stopped

--- a/public/client.js
+++ b/public/client.js
@@ -84,13 +84,28 @@ socket.on('users', ({ hostId, users }) => {
   });
 });
 
-const themeToggle = document.getElementById('themeToggle');
-themeToggle.addEventListener('click', () => {
-  document.body.classList.toggle('light');
+const contextMenu = document.getElementById('contextMenu');
+const toggleTheme = document.getElementById('toggleTheme');
+
+board.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  contextMenu.style.left = `${e.pageX}px`;
+  contextMenu.style.top = `${e.pageY}px`;
+  contextMenu.classList.remove('hidden');
 });
 
-const zoom = document.getElementById('zoom');
-zoom.addEventListener('input', () => {
-  scale = zoom.value / 100;
+document.addEventListener('click', () => {
+  contextMenu.classList.add('hidden');
+});
+
+toggleTheme.addEventListener('click', () => {
+  document.body.classList.toggle('light');
+  contextMenu.classList.add('hidden');
+});
+
+board.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const delta = e.deltaY < 0 ? 0.1 : -0.1;
+  scale = Math.min(1.8, Math.max(1, scale + delta));
   board.style.transform = `scale(${scale})`;
 });

--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,14 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body class="dark">
-<div id="controls">
-  <button id="themeToggle">Toggle Theme</button>
-  <label>Zoom <input type="range" id="zoom" min="100" max="180" value="100"></label>
+<div id="contextMenu" class="hidden">
+  <ul>
+    <li id="settingsItem">Settings ▸
+      <ul id="settingsSubMenu" class="hidden">
+        <li id="toggleTheme">Toggle Theme</li>
+      </ul>
+    </li>
+  </ul>
 </div>
 <div id="layout">
   <div id="users"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -8,10 +8,6 @@ body.light {
   background: #fff;
   color: #000;
 }
-#controls {
-  padding: 10px;
-  text-align: center;
-}
 #layout {
   display: flex;
 }
@@ -24,6 +20,7 @@ body.light {
   margin: 0 auto;
   width: 80vw;
   height: 80vh;
+  transform-origin: 0 0;
   background: #fff;
   border: 1px solid #ccc;
 }
@@ -36,4 +33,47 @@ body.light #board {
 }
 .user label {
   margin-left: 5px;
+}
+
+#contextMenu {
+  position: absolute;
+  background: #333;
+  border: 1px solid #555;
+  color: #eee;
+  z-index: 1000;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-size: 14px;
+}
+
+#contextMenu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#contextMenu li {
+  padding: 5px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+#contextMenu li:hover {
+  background: #555;
+}
+
+#contextMenu ul ul {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  display: none;
+}
+
+#contextMenu li:hover > ul {
+  display: block;
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- add subcontext menu for theme toggle
- allow zoom via mouse wheel when over board
- remove old controls UI
- update docker-compose config to match recommendation
- document right-click menu and wheel zoom in README

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685bceb9722c83298e7ed8d714e9aebe