### PR TITLE
Add clear board menu option and host-only action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 - Prompt for username on connect
 - Host or join a session
 - Host can enable/disable drawing for each user
-- Dark mode (default) and light mode toggle via right-click menu
+- Right-click menu for toggling dark mode
+- Host can clear the board via the right-click menu
 - Whiteboard centered and uses 80% of the window
 - Zoom with mouse wheel up to 180%, never smaller than 100%
 

--- a/public/client.js
+++ b/public/client.js
@@ -57,6 +57,7 @@ socket.on('history', (hist) => {
 });
 
 socket.on('users', ({ hostId, users }) => {
+  currentHostId = hostId;
   usersDiv.innerHTML = '';
   Object.entries(users).forEach(([id, u]) => {
     const div = document.createElement('div');
@@ -82,10 +83,17 @@ socket.on('users', ({ hostId, users }) => {
     div.appendChild(label);
     usersDiv.appendChild(div);
   });
+  if (socket.id === hostId) {
+    clearBoardBtn.classList.remove('hidden');
+  } else {
+    clearBoardBtn.classList.add('hidden');
+  }
 });
 
 const contextMenu = document.getElementById('contextMenu');
 const toggleTheme = document.getElementById('toggleTheme');
+const clearBoardBtn = document.getElementById('clearBoard');
+let currentHostId = null;
 
 board.addEventListener('contextmenu', (e) => {
   e.preventDefault();
@@ -101,6 +109,15 @@ document.addEventListener('click', () => {
 toggleTheme.addEventListener('click', () => {
   document.body.classList.toggle('light');
   contextMenu.classList.add('hidden');
+});
+
+clearBoardBtn.addEventListener('click', () => {
+  socket.emit('clear-board');
+  contextMenu.classList.add('hidden');
+});
+
+socket.on('clear-board', () => {
+  ctx.clearRect(0, 0, board.width, board.height);
 });
 
 board.addEventListener('wheel', (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,8 @@
 <body class="dark">
 <div id="contextMenu" class="hidden">
   <ul>
-    <li id="settingsItem">Settings ▸
-      <ul id="settingsSubMenu" class="hidden">
-        <li id="toggleTheme">Toggle Theme</li>
-      </ul>
-    </li>
+    <li id="toggleTheme">Toggle dark mode</li>
+    <li id="clearBoard">Clear board</li>
   </ul>
 </div>
 <div id="layout">

--- a/public/style.css
+++ b/public/style.css
@@ -63,16 +63,6 @@ body.light #board {
   background: #555;
 }
 
-#contextMenu ul ul {
-  position: absolute;
-  left: 100%;
-  top: 0;
-  display: none;
-}
-
-#contextMenu li:hover > ul {
-  display: block;
-}
 
 .hidden {
   display: none;

--- a/server.js
+++ b/server.js
@@ -41,6 +41,13 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('clear-board', () => {
+    if (socket.id === hostId) {
+      history.length = 0;
+      io.emit('clear-board');
+    }
+  });
+
   socket.on('disconnect', () => {
     delete users[socket.id];
     if (socket.id === hostId) {


### PR DESCRIPTION
## Summary
- add context menu items for dark mode and clearing the board
- hide `Clear board` item from non-host users and wire up socket event
- server resets drawing history when host requests a clear
- remove unused submenu CSS
- document new context menu behaviour in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685bd1bfec6c83298495a7bee06204fa