### PR TITLE
Improve whiteboard drawing and menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 - Host can enable/disable drawing for each user
 - Right-click menu for toggling dark mode
 - Host can clear the board via the right-click menu
+- Clear board option visible for everyone but only the host can activate it
+- Crisp drawings rendered using SVG
 - Whiteboard centered and uses 80% of the window
 - Zoom with mouse wheel up to 180%, never smaller than 100%
 

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
 </div>
 <div id="layout">
   <div id="users"></div>
-  <canvas id="board" width="800" height="600"></canvas>
+  <svg id="board" width="800" height="600"></svg>
 </div>
 <script src="/socket.io/socket.io.js"></script>
 <script src="client.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -27,6 +27,11 @@ body.light {
 body.light #board {
   background: #fff;
 }
+#board line {
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
 .user {
   display: flex;
   align-items: center;
@@ -57,6 +62,11 @@ body.light #board {
   padding: 5px 10px;
   cursor: pointer;
   white-space: nowrap;
+}
+
+#contextMenu li.disabled {
+  color: #777;
+  pointer-events: none;
 }
 
 #contextMenu li:hover {


### PR DESCRIPTION
## Summary
- switch drawing surface from `<canvas>` to `<svg>` for sharper lines
- keep board size consistent and fix pointer calculations
- show context menu for everyone but disable 'Clear board' unless host
- add styles for disabled menu items
- document SVG lines in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bd5f0e7b083298fcef25d94faebe5