### PR TITLE
Fix drawing stop event

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -37,7 +37,7 @@ board.addEventListener('mousedown', (e) => {
 });
 
 board.addEventListener('mouseup', () => { drawing = false; });
-board.addEventListener('mouseout', () => { drawing = false; });
+board.addEventListener('mouseleave', () => { drawing = false; });
 board.addEventListener('mousemove', (e) => {
   if (!drawing) return;
   const pos = getPos(e);


### PR DESCRIPTION
## Summary
- update client drawing code to stop drawing on `mouseleave` instead of `mouseout`

## Testing
- `npm install`
- `npm start` *(server runs then manually stopped with Ctrl-C)*

------
https://chatgpt.com/codex/tasks/task_e_685bda769d748329b4f38867572cef09