### PR TITLE
Add clear board handler and pointer-based zoom

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -164,6 +164,7 @@ toggleTheme.addEventListener('click', () => {
 
 clearBoardBtn.addEventListener('click', () => {
   if (socket.id === currentHostId) {
+    board.innerHTML = '';
     socket.emit('clear-board');
   }
   contextMenu.classList.add('hidden');
@@ -175,6 +176,10 @@ socket.on('clear-board', () => {
 
 board.addEventListener('wheel', (e) => {
   e.preventDefault();
+  const rect = board.getBoundingClientRect();
+  const offsetX = e.clientX - rect.left;
+  const offsetY = e.clientY - rect.top;
+  board.style.transformOrigin = `${offsetX}px ${offsetY}px`;
   const delta = e.deltaY < 0 ? 0.1 : -0.1;
   scale = Math.min(1.8, Math.max(1, scale + delta));
   updateTransform();


### PR DESCRIPTION
## Summary
- clear board immediately when the host clicks the button
- zoom in/out using the mouse location as the origin

## Testing
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_685be204266c8329b81d437ae5e92787