### PR TITLE
Make board fill screen and update dark mode styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 - Host can clear the board via the right-click menu
 - Clear board option visible for everyone but only the host can activate it
 - Crisp drawings rendered using SVG
-- Whiteboard centered and uses 80% of the window
+- Whiteboard fills the entire window
 - Zoom with mouse wheel up to 180%, never smaller than 100%
 
 ## Quick Start

--- a/public/style.css
+++ b/public/style.css
@@ -4,33 +4,53 @@ body {
   background: #111;
   color: #eee;
 }
+
 body.light {
   background: #fff;
   color: #000;
 }
+
 #layout {
-  display: flex;
+  position: relative;
 }
+
 #users {
   width: 200px;
   padding: 10px;
   overflow-y: auto;
-  position: relative;
-  z-index: 1;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
   background: inherit;
 }
+
 #board {
-  margin: 0 auto;
-  width: 80vw;
-  height: 80vh;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
   transform-origin: 50% 50%;
   background: #fff;
   border: 1px solid #ccc;
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  color: #000;
   z-index: 0;
 }
+
 body.light #board {
   background: #fff;
+  color: #000;
+}
+
+body.dark #board {
+  background: #2c2f38;
+  color: #7f8187;
+}
+
+body.dark #users {
+  background: #47575e;
 }
 #board line {
   stroke: currentColor;


### PR DESCRIPTION
## Summary
- style board to take full viewport
- float user list in top-left
- dark mode uses new background and drawing colors
- update README

## Testing
- `npm install`
- `npm start` *(fails to exit, but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_685be4727300832983ad6db28de21c79