### PR TITLE
Fix board clearing and enforce full-screen layout

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -164,7 +164,6 @@ toggleTheme.addEventListener('click', () => {
 
 clearBoardBtn.addEventListener('click', () => {
   if (socket.id === currentHostId) {
-    board.innerHTML = '';
     socket.emit('clear-board');
   }
   contextMenu.classList.add('hidden');

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
 </div>
 <div id="layout">
   <div id="users"></div>
-  <svg id="board" width="800" height="600"></svg>
+  <svg id="board"></svg>
 </div>
 <script src="/socket.io/socket.io.js"></script>
 <script src="client.js"></script>

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const io = new Server(server);
 
 const PORT = process.env.PORT || 3000;
 
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public'), { maxAge: 0 }));
 
 let hostId = null;
 const users = {}; // { socketId: { username, canDraw } }


### PR DESCRIPTION
## Summary
- ensure board clearing event triggers on all clients
- remove fixed SVG size for consistent full-screen board
- disable caching of static assets

## Testing
- `npm install`
- `node server.js` (started and logged `Server running on port 3000`)


------
https://chatgpt.com/codex/tasks/task_e_685be6515c7883298c2e7dc79c61403d