### PR TITLE
Fix board clearing and sync theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 - Prompt for username on connect
 - Host or join a session
 - Host can enable/disable drawing for each user
-- Right-click menu for toggling dark mode
+- Right-click menu for toggling dark mode, synced across users
 - Host can clear the board via the right-click menu
 - Clear board option visible for everyone but only the host can activate it
 - Crisp drawings rendered using SVG
 - Whiteboard fills the entire window
-- Zoom with mouse wheel up to 180%, never smaller than 100%
+- Zoom with mouse wheel up to 130%, never smaller than 100%
 
 ## Quick Start
 ```bash

--- a/public/client.js
+++ b/public/client.js
@@ -145,6 +145,12 @@ const contextMenu = document.getElementById('contextMenu');
 const toggleTheme = document.getElementById('toggleTheme');
 const clearBoardBtn = document.getElementById('clearBoard');
 let currentHostId = null;
+let currentTheme = 'dark';
+
+socket.on('theme', (th) => {
+  currentTheme = th;
+  document.body.classList.toggle('light', th === 'light');
+});
 
 board.addEventListener('contextmenu', (e) => {
   e.preventDefault();
@@ -158,7 +164,8 @@ document.addEventListener('click', () => {
 });
 
 toggleTheme.addEventListener('click', () => {
-  document.body.classList.toggle('light');
+  const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  socket.emit('toggle-theme', newTheme);
   contextMenu.classList.add('hidden');
 });
 
@@ -170,7 +177,7 @@ clearBoardBtn.addEventListener('click', () => {
 });
 
 socket.on('clear-board', () => {
-  board.innerHTML = '';
+  board.replaceChildren();
 });
 
 board.addEventListener('wheel', (e) => {
@@ -180,6 +187,6 @@ board.addEventListener('wheel', (e) => {
   const offsetY = e.clientY - rect.top;
   board.style.transformOrigin = `${offsetX}px ${offsetY}px`;
   const delta = e.deltaY < 0 ? 0.1 : -0.1;
-  scale = Math.min(1.8, Math.max(1, scale + delta));
+  scale = Math.min(1.3, Math.max(1, scale + delta));
   updateTransform();
 });

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ app.use(express.static(path.join(__dirname, 'public'), { maxAge: 0 }));
 let hostId = null;
 const users = {}; // { socketId: { username, canDraw } }
 const history = [];
+let theme = 'dark';
 
 io.on('connection', (socket) => {
   console.log('user connected', socket.id);
@@ -25,6 +26,7 @@ io.on('connection', (socket) => {
     // allow drawing for everyone by default
     users[socket.id] = { username, canDraw: true };
     socket.emit('history', history);
+    socket.emit('theme', theme);
     io.emit('users', { hostId, users });
   });
 
@@ -47,6 +49,11 @@ io.on('connection', (socket) => {
       history.length = 0;
       io.emit('clear-board');
     }
+  });
+
+  socket.on('toggle-theme', (newTheme) => {
+    theme = newTheme === 'light' ? 'light' : 'dark';
+    io.emit('theme', theme);
   });
 
   socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- make dark mode synced across participants
- switch to `board.replaceChildren()` for clearing the board
- limit zoom to 130%
- document new zoom limit and synced dark mode

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_685be88a25948329bb0a75327818894f