### PR TITLE
Add admin user and debug menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@ A lightweight, browser-based whiteboard for up to **6 users**. No database requi
 
 ## Features
 - Prompt for username on connect
-- Host or join a session
-- Host can enable/disable drawing for each user
+- Users whose name begins with `!` gain admin powers
+- Admins can clear the board via the right-click menu
 - Right-click menu for toggling dark mode, synced across users
-- Host can clear the board via the right-click menu
-- Clear board option visible for everyone but only the host can activate it
+- Debug menu for admins to adjust maximum zoom
 - Crisp drawings rendered using SVG
 - Whiteboard fills the entire window
-- Zoom with mouse wheel up to 130%, never smaller than 100%
+- Zoom with mouse wheel (default limit 130%, adjustable by admins)
 
 ## Quick Start
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,13 @@
   </ul>
 </div>
 <div id="layout">
-  <div id="users"></div>
+  <div id="users">
+    <button id="debugBtn" class="hidden">Debug</button>
+  </div>
+  <div id="debugWindow" class="hidden">
+    <label>Max zoom <input id="maxZoomInput" type="number" step="0.1" min="1" value="1.3"></label>
+    <button id="closeDebug">Close</button>
+  </div>
   <svg id="board"></svg>
 </div>
 <script src="/socket.io/socket.io.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -102,3 +102,18 @@ body.dark #users {
 .hidden {
   display: none;
 }
+
+#debugWindow {
+  position: absolute;
+  background: #333;
+  color: #eee;
+  border: 1px solid #555;
+  padding: 10px;
+  top: 50px;
+  left: 10px;
+  z-index: 1001;
+}
+
+#debugBtn {
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- remove host/join flow and treat all users the same
- allow usernames starting with `!` to get admin powers
- admins can clear the board and access a debug window
- debug window lets admins change maximum zoom
- hide leading `!` in the user list

## Testing
- `npm install`
- `npm start` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_685bebe987a083298b0df20789bcf58c