### PR TITLE
Add clipboard image support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <div id="userList"></div>
   <ul id="contextMenu" class="hidden">
     <li id="clearBoard">Clear Board</li>
+    <li id="pasteImage">Paste Image</li>
   </ul>
   <svg id="board"></svg>
 

--- a/public/style.css
+++ b/public/style.css
@@ -56,3 +56,11 @@ body {
 .hidden {
   display: none;
 }
+
+.image-group {
+  cursor: move;
+}
+
+.image-group rect {
+  pointer-events: none;
+}

--- a/server.js
+++ b/server.js
@@ -29,9 +29,29 @@ io.on('connection', (socket) => {
   socket.on('draw', (data) => {
     const user = users[socket.id];
     if (!user) return;
-    const line = { ...data, color: user.color };
+    const line = { type: 'line', ...data, color: user.color };
     history.push(line);
     socket.broadcast.emit('draw', line);
+  });
+
+  socket.on('add-image', (obj) => {
+    const user = users[socket.id];
+    if (!user) return;
+    const img = { type: 'image', ...obj, color: user.color };
+    history.push(img);
+    socket.broadcast.emit('add-image', img);
+  });
+
+  socket.on('update-image', (obj) => {
+    if (!users[socket.id]) return;
+    const item = history.find((h) => h.type === 'image' && h.id === obj.id);
+    if (item) {
+      item.x = obj.x;
+      item.y = obj.y;
+      item.width = obj.width;
+      item.height = obj.height;
+    }
+    socket.broadcast.emit('update-image', obj);
   });
 
   socket.on('clear-board', () => {


### PR DESCRIPTION
## Summary
- insert `Paste Image` option in context menu
- confirm before clearing the whiteboard
- support adding, moving, and resizing pasted images with colored borders
- broadcast image changes via Socket.io

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7c5eb60832990e6c22f6e18e4c8